### PR TITLE
Update maven to new logger Minestom system

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    api("com.github.Minestom:Minestom:17ef1c2f57")
+    api("com.github.Minestom:Minestom:42195c536b")
     api("com.influxdb:influxdb-client-java:6.5.0")
     implementation("net.kyori:adventure-text-minimessage:4.11.0")
     implementation("com.typesafe:config:1.4.2")


### PR DESCRIPTION
Since this commit: https://github.com/Minestom/Minestom/commit/d7e958fa07820882150567416f76b759a1dace6d the `getLogger()` method from extension now use `net.kyori.adventure.text.logger.slf4j.ComponentLogger`